### PR TITLE
Try switching to debian base to fix dll load issue

### DIFF
--- a/MapDiffBot/Core/GitHubClientFactory.cs
+++ b/MapDiffBot/Core/GitHubClientFactory.cs
@@ -49,6 +49,7 @@ namespace MapDiffBot.Core
 		/// </summary>
 		/// <param name="gitHubConfigurationOptions">The <see cref="IOptions{TOptions}"/> containing the value of <see cref="gitHubConfiguration"/></param>
 		/// <param name="webRequestManager">The value of <see cref="webRequestManager"/></param>
+		/// <param name="logger">The value of <see cref="logger"/></param>
 		public GitHubClientFactory(IOptions<GitHubConfiguration> gitHubConfigurationOptions, IWebRequestManager webRequestManager, ILogger<GitHubClientFactory> logger)
 		{
 			gitHubConfiguration = gitHubConfigurationOptions?.Value ?? throw new ArgumentNullException(nameof(gitHubConfigurationOptions));

--- a/MapDiffBot/Core/PayloadProcessor.cs
+++ b/MapDiffBot/Core/PayloadProcessor.cs
@@ -70,7 +70,18 @@ namespace MapDiffBot.Core
 		/// <see cref="Dictionary{TKey, TValue}"/> of operation name to their <see cref="CancellationToken"/>
 		/// </summary>
 		readonly Dictionary<string, CancellationTokenSource> mapDiffOperations;
-		
+
+		/// <summary>
+		/// Construct a <see cref="PayloadProcessor"/>
+		/// </summary>
+		/// <param name="gitHubConfigurationOptions">The <see cref="IOptions{TOptions}"/> containing the value of <see cref="gitHubConfiguration"/></param>
+		/// <param name="generatorFactory">The value of <see cref="generatorFactory"/></param>
+		/// <param name="serviceProvider">The value of <see cref="serviceProvider"/></param>
+		/// <param name="repositoryManager">The value of <see cref="repositoryManager"/></param>
+		/// <param name="ioManager">The value of <see cref="ioManager"/></param>
+		/// <param name="logger">The value of <see cref="logger"/></param>
+		/// <param name="stringLocalizer">The value of <see cref="stringLocalizer"/></param>
+		/// <param name="backgroundJobClient">The value of <see cref="backgroundJobClient"/></param>
 		public PayloadProcessor(IOptions<GitHubConfiguration> gitHubConfigurationOptions, IGeneratorFactory generatorFactory, IServiceProvider serviceProvider, ILocalRepositoryManager repositoryManager, IIOManager ioManager, ILogger<PayloadProcessor> logger, IStringLocalizer<PayloadProcessor> stringLocalizer, IBackgroundJobClient backgroundJobClient)
 		{
 			gitHubConfiguration = gitHubConfigurationOptions?.Value ?? throw new ArgumentNullException(nameof(gitHubConfigurationOptions));

--- a/MapDiffBot/Core/PayloadProcessor.cs
+++ b/MapDiffBot/Core/PayloadProcessor.cs
@@ -27,7 +27,7 @@ namespace MapDiffBot.Core
 		/// <summary>
 		/// The URL to direct user to report issues at
 		/// </summary>
-		const string issueReportUrl = "https://github.com/MapDiffBot/MapDiffBot/issues/new";
+		const string issueReportUrl = "https://github.com/MapDiffBot/MapDiffBot/issues";
 		/// <summary>
 		/// The intermediate directory for operations
 		/// </summary>

--- a/MapDiffBot/Dockerfile
+++ b/MapDiffBot/Dockerfile
@@ -19,7 +19,6 @@ RUN dotnet build -c Docker -o /app
 
 FROM build AS publish
 RUN dotnet publish -c Docker -o /app
-RUN cp runtimes
 
 FROM base AS final
 WORKDIR /app

--- a/MapDiffBot/Dockerfile
+++ b/MapDiffBot/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/aspnetcore AS base
+FROM microsoft/aspnetcore:2.0.6-jessie AS base
 WORKDIR /app
 EXPOSE 80
 
@@ -8,7 +8,7 @@ COPY . .
 WORKDIR /src/SpacemanDMM
 RUN cargo build -p cli --release
 
-FROM microsoft/aspnetcore-build AS build
+FROM microsoft/aspnetcore-build:2.0.6-2.1.101-jessie AS build
 WORKDIR /src/SpacemanDMM/target/release/
 COPY --from=compiler /src/SpacemanDMM/target/release/dmm-tools .
 WORKDIR /src
@@ -19,6 +19,7 @@ RUN dotnet build -c Docker -o /app
 
 FROM build AS publish
 RUN dotnet publish -c Docker -o /app
+RUN cp runtimes
 
 FROM base AS final
 WORKDIR /app

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,6 @@
 pull_requests:
   do_not_increment_build_number: true
+skip_branch_with_pr: true
 environment:
   repo_token:
     secure: 2IfF4fXwHC6ix7KXkbvghzUT7zFzOjWWQKypfm/efc7XrUAHZdplFuLU08JJ37yk


### PR DESCRIPTION
Bug:

```
System.TypeInitializationException: The type initializer for 'LibGit2Sharp.Core.NativeMethods' threw an exception. ---> System.DllNotFoundException: Unable to load DLL 'git2-2d2a602': The specified module or one of its dependencies could not be found.
 (Exception from HRESULT: 0x8007007E)
   at LibGit2Sharp.Core.NativeMethods.git_libgit2_init()
   at LibGit2Sharp.Core.NativeMethods.LoadNativeLibrary()
   at LibGit2Sharp.Core.NativeMethods..cctor()
   --- End of inner exception stack trace ---
   at LibGit2Sharp.Core.NativeMethods.git_repository_open(git_repository*& repository, FilePath path)
   at LibGit2Sharp.Core.Proxy.git_repository_open(String path)
   at LibGit2Sharp.Repository..ctor(String path, RepositoryOptions options, RepositoryRequiredParameter requiredParameter)
   at MapDiffBot.Core.LocalRepositoryManager.<>c__DisplayClass3_0.<CreateRepositoryObject>b__0() in /src/MapDiffBot/Core/LocalRepositoryManager.cs:line 47
   at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task& currentTaskSlot)
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at MapDiffBot.Core.LocalRepositoryManager.<CreateRepositoryObject>d__3.MoveNext() in /src/MapDiffBot/Core/LocalRepositoryManager.cs:line 45
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1.ConfiguredTaskAwaiter.GetResult()
   at MapDiffBot.Core.LocalRepositoryManager.<TryLoadRepository>d__4.MoveNext() in /src/MapDiffBot/Core/LocalRepositoryManager.cs:line 122
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1.ConfiguredTaskAwaiter.GetResult()
   at MapDiffBot.Core.LocalRepositoryManager.<GetRepository>d__5.MoveNext() in /src/MapDiffBot/Core/LocalRepositoryManager.cs:line 142
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1.ConfiguredTaskAwaiter.GetResult()
   at MapDiffBot.Core.PayloadProcessor.<GenerateDiffs>d__13.MoveNext() in /src/MapDiffBot/Core/PayloadProcessor.cs:line 232
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at MapDiffBot.Core.PayloadProcessor.<ScanPullRequest>d__12.MoveNext() in /src/MapDiffBot/Core/PayloadProcessor.cs:line 154
```

Reference: https://github.com/libgit2/libgit2sharp/issues/1533#issuecomment-369900918