### PR TITLE
Use the build image as a base

### DIFF
--- a/MapDiffBot/Dockerfile
+++ b/MapDiffBot/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/aspnetcore:2.0.6-jessie AS base
+FROM microsoft/aspnetcore-build:2.0.6-2.1.101-jessie AS base
 WORKDIR /app
 EXPOSE 80
 


### PR DESCRIPTION
Workaround for the aspnetcore image not seeming to have the necessary stuff for libgit2

Fixes #29 